### PR TITLE
feat: change base image

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,5 +1,7 @@
 name: Build and Push Docker Image
 
+
+
 on:
     push:
         branches:
@@ -11,6 +13,8 @@ on:
 jobs:
     build:
         runs-on: ubuntu-latest
+        env:
+          BASE_IMAGE: eclipse-temurin:25-jre-noble
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -40,7 +44,7 @@ jobs:
                   push: ${{ github.event_name != 'pull_request' }}
                   tags: ${{ steps.meta.outputs.tags }}
                   build-args: |
-                      BASE_IMAGE=${{ vars.BASE_IMAGE }}
+                      BASE_IMAGE=${{ env.BASE_IMAGE }}
                       IMAGE_VERSION=${{ steps.meta.outputs.version }}
                   annotations: ${{ steps.meta.outputs.annotations }}
                   provenance: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE="eclipse-temurin:25-jre-ubi10-minimal"
+ARG BASE_IMAGE="eclipse-temurin:25-jre-noble"
 ARG DOWNLOADER_IMAGE="voidcube/hytale-downloader:2026.1.9"
 
 FROM ${DOWNLOADER_IMAGE} AS downloader
@@ -7,8 +7,9 @@ FROM ${BASE_IMAGE} AS base
 
 ARG IMAGE_VERSION
 
-RUN microdnf install -y unzip jq curl && \
-    groupadd -r -g 1000 hytale && useradd -r -u 1000 -g hytale hytale
+RUN apt-get update && apt-get install -y unzip jq curl && \
+    deluser ubuntu && groupadd -r -g 1000 hytale && useradd -r -u 1000 -g hytale hytale && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ FROM ${BASE_IMAGE} AS base
 
 ARG IMAGE_VERSION
 
-RUN apt-get update && apt-get install -y unzip jq curl && \
+RUN apt-get update && apt-get install --no-install-recommends -y unzip jq curl && \
     deluser ubuntu && groupadd -r -g 1000 hytale && useradd -r -u 1000 -g hytale hytale && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Change base java image from ubi to ubuntu because it fixes problems with local builds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the container base image to a newer Java runtime.
  * Changed package installation in the image build and added explicit cleanup to reduce image artifacts and size.
  * Adjusted container user and group setup for consistent runtime ownership and permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->