### PR TITLE
feat(sops): encrypt cached auth tokens at rest with sops+age

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 ARG BASE_IMAGE="eclipse-temurin:25.0.3_9-jre-noble"
 ARG DOWNLOADER_IMAGE="voidcube/hytale-downloader:2026.5.30"
+ARG SOPS_IMAGE="ghcr.io/getsops/sops:v3.13.2-alpine"
+
+FROM ${SOPS_IMAGE} as sops
 
 FROM ${DOWNLOADER_IMAGE} AS downloader
 
@@ -12,8 +15,10 @@ RUN apt-get update && apt-get install --no-install-recommends -y unzip jq curl &
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+COPY scripts/ /opt/voidcube/scripts/
 
-COPY --from=downloader /bin/hytale-downloader /usr/local/bin
+COPY --from=downloader /bin/hytale-downloader /usr/local/bin/hytale-downloader
+COPY --from=sops /usr/local/bin/sops /usr/local/bin/sops
 
 USER hytale
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE="eclipse-temurin:25.0.3_9-jre-noble"
 ARG DOWNLOADER_IMAGE="voidcube/hytale-downloader:2026.5.30"
 ARG SOPS_IMAGE="ghcr.io/getsops/sops:v3.13.2-alpine"
 
-FROM ${SOPS_IMAGE} as sops
+FROM ${SOPS_IMAGE} AS sops
 
 FROM ${DOWNLOADER_IMAGE} AS downloader
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,12 @@
 services:
   hytale-server:
     image: voidcube/hytale-server
+    build:
+      context: .
+      platforms: [linux/amd64]
     container_name: hytale-server
     restart: unless-stopped
+    env_file: .env
     ports:
       - "5520:5520/udp"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,9 @@ services:
       platforms: [linux/amd64]
     container_name: hytale-server
     restart: unless-stopped
-    env_file: .env
+    env_file:
+      - path: .env
+        required: false
     ports:
       - "5520:5520/udp"
     volumes:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,7 +1,12 @@
 #!/bin/bash
 
-
 set -euo pipefail
+
+echo "Loading scripts..."
+
+source /opt/voidcube/scripts/sops.sh
+
+echo "Done scripts loaded"
 
 IDENTITY_TOKEN=${IDENTITY_TOKEN:-""}
 SESSION_TOKEN=${SESSION_TOKEN:-""}
@@ -14,6 +19,7 @@ GAME_VERSION_CACHE_FILE=${GAME_VERSION_CACHE_FILE:-".game_version"}
 SKIP_GAME_DOWNLOAD=${SKIP_GAME_DOWNLOAD:-"0"}
 DOWNLOADER=${DOWNLOADER:-"hytale-downloader"}
 AUTH_CACHE_FILE=${AUTH_CACHE_FILE:-".hytale-auth-tokens.json"}
+DOWNLOADER_AUTH_CACHE_FILE=${DOWNLOADER_AUTH_CACHE_FILE:-".hytale-downloader-credentials.json"}
 ASSET_PACK=${ASSET_PACK:-"Assets.zip"}
 LEVERAGE_AHEAD_OF_TIME_CACHE=${LEVERAGE_AHEAD_OF_TIME_CACHE:-"0"}
 AHEAD_OF_TIME_CACHE_PATH=${AOTCACHE_PATH:-"HytaleServer.aot"}
@@ -127,6 +133,7 @@ check_token_envs() {
 
 # Function to load cached tokens
 load_cached_tokens() {
+    sops_decrypt_file "$AUTH_CACHE_FILE"
     ACCESS_TOKEN=$(jq -r '.access_token' "$AUTH_CACHE_FILE")
     REFRESH_TOKEN=$(jq -r '.refresh_token' "$AUTH_CACHE_FILE")
     PROFILE_UUID=$(jq -r '.profile_uuid' "$AUTH_CACHE_FILE")
@@ -153,6 +160,7 @@ save_auth_tokens() {
   "timestamp": $(date +%s)
 }
 EOF
+    sops_encrypt_file "$AUTH_CACHE_FILE"
     echo "✓ Authentication tokens cached for future use"
 }
 
@@ -333,6 +341,7 @@ save_game_version() {
 }
 
 # Check if server files were downloaded correctly
+sops_decrypt_file "$DOWNLOADER_AUTH_CACHE_FILE"
 if check_game_version; then
     if [ ! -f "server.zip" ]; then
         echo "Starting Hytale downloader..."
@@ -341,6 +350,7 @@ if check_game_version; then
     extract_server_files
     save_game_version
 fi
+sops_encrypt_file "$DOWNLOADER_AUTH_CACHE_FILE"
 
 # Check for cached authentication tokens
 if check_cached_tokens && load_cached_tokens; then
@@ -353,6 +363,8 @@ elif check_token_envs; then
 else
     echo "Skipping login prompt..."
 fi
+
+sops_unset_envs
 
 echo "Starting Hytale server..."
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -350,7 +350,8 @@ if check_game_version; then
     extract_server_files
     save_game_version
 fi
-sops_encrypt_file "$DOWNLOADER_AUTH_CACHE_FILE"
+# Soft-fail: a re-encrypt failure must not abort the entrypoint (would leave creds plaintext + kill server)
+sops_encrypt_file "$DOWNLOADER_AUTH_CACHE_FILE" || echo "⚠ Warning: failed to re-encrypt $DOWNLOADER_AUTH_CACHE_FILE" >&2
 
 # Check for cached authentication tokens
 if check_cached_tokens && load_cached_tokens; then

--- a/scripts/sops.sh
+++ b/scripts/sops.sh
@@ -1,0 +1,47 @@
+SOPS_AGE_KEY=${SOPS_AGE_KEY:-""}
+SOPS_AGE_RECIPIENT=${SOPS_AGE_RECIPIENT:-""}
+SOPS_ENABLED=${SOPS_ENABLED:-0}
+SOPS_CMD=${SOPS_CMD:-"sops"}
+
+export SOPS_AGE_KEY
+
+if [[ -n "$SOPS_AGE_KEY" && -n "$SOPS_AGE_RECIPIENT" ]]; then
+    SOPS_ENABLED=1
+fi
+
+sops_encrypt_file() {
+    file=$1
+    if [[ $SOPS_ENABLED == 1 && -n $file && -f /data/${file} ]]; then
+        if [ -z "$SOPS_AGE_RECIPIENT" ]; then
+            echo "✗ SOPS_AGE_RECIPIENT (age public key) not set, cannot encrypt $file" >&2
+            return 1
+        fi
+        if $SOPS_CMD filestatus "/data/${file}" | grep -q '"encrypted":true'; then
+            echo "• File $file already encrypted, skipping"
+        elif $SOPS_CMD encrypt --age "$SOPS_AGE_RECIPIENT" --in-place "/data/${file}"; then
+            echo "✓ File $file encrypted"
+        else
+            echo "✗ Encrypt failed for $file" >&2
+            return 1
+        fi
+    fi
+}
+
+sops_decrypt_file() {
+    file=$1
+    if [[ $SOPS_ENABLED == 1 && -n $file && -f /data/${file} ]]; then
+        if ! $SOPS_CMD filestatus "/data/${file}" | grep -q '"encrypted":true'; then
+            echo "• File $file not encrypted, skipping"
+        elif $SOPS_CMD decrypt --in-place "/data/${file}"; then
+            echo "✓ File $file decrypted"
+        else
+            echo "✗ Decrypt failed for $file" >&2
+            return 1
+        fi
+    fi
+}
+
+sops_unset_envs() {
+    unset SOPS_AGE_RECIPIENT
+    unset SOPS_AGE_KEY
+}

--- a/scripts/sops.sh
+++ b/scripts/sops.sh
@@ -9,6 +9,7 @@ if [[ -n "$SOPS_AGE_KEY" && -n "$SOPS_AGE_RECIPIENT" ]]; then
     SOPS_ENABLED=1
 fi
 
+# Encrypt file using AGE encryption
 sops_encrypt_file() {
     file=$1
     if [[ $SOPS_ENABLED == 1 && -n $file && -f /data/${file} ]]; then
@@ -27,6 +28,7 @@ sops_encrypt_file() {
     fi
 }
 
+# Decrypt file using AGE encryption
 sops_decrypt_file() {
     file=$1
     if [[ $SOPS_ENABLED == 1 && -n $file && -f /data/${file} ]]; then
@@ -41,6 +43,7 @@ sops_decrypt_file() {
     fi
 }
 
+# Unset AGE key env vars before handing off to the server process
 sops_unset_envs() {
     unset SOPS_AGE_RECIPIENT
     unset SOPS_AGE_KEY

--- a/scripts/sops.sh
+++ b/scripts/sops.sh
@@ -1,23 +1,33 @@
 SOPS_AGE_KEY=${SOPS_AGE_KEY:-""}
 SOPS_AGE_RECIPIENT=${SOPS_AGE_RECIPIENT:-""}
-SOPS_ENABLED=${SOPS_ENABLED:-0}
+SOPS_ENABLED=${SOPS_ENABLED:-""}
 SOPS_CMD=${SOPS_CMD:-"sops"}
 
 export SOPS_AGE_KEY
 
-if [[ -n "$SOPS_AGE_KEY" && -n "$SOPS_AGE_RECIPIENT" ]]; then
-    SOPS_ENABLED=1
+# Honor an explicit SOPS_ENABLED; otherwise auto-enable only when both keys present
+if [ -z "$SOPS_ENABLED" ]; then
+    if [[ -n "$SOPS_AGE_KEY" && -n "$SOPS_AGE_RECIPIENT" ]]; then
+        SOPS_ENABLED=1
+    else
+        SOPS_ENABLED=0
+    fi
 fi
+
+# Return 0 if the given /data file is sops-encrypted (whitespace-tolerant JSON parse)
+sops_is_encrypted() {
+    [ "$($SOPS_CMD filestatus "$1" | jq -r '.encrypted')" = "true" ]
+}
 
 # Encrypt file using AGE encryption
 sops_encrypt_file() {
-    file=$1
+    local file="$1"
     if [[ $SOPS_ENABLED == 1 && -n $file && -f /data/${file} ]]; then
         if [ -z "$SOPS_AGE_RECIPIENT" ]; then
             echo "✗ SOPS_AGE_RECIPIENT (age public key) not set, cannot encrypt $file" >&2
             return 1
         fi
-        if $SOPS_CMD filestatus "/data/${file}" | grep -q '"encrypted":true'; then
+        if sops_is_encrypted "/data/${file}"; then
             echo "• File $file already encrypted, skipping"
         elif $SOPS_CMD encrypt --age "$SOPS_AGE_RECIPIENT" --in-place "/data/${file}"; then
             echo "✓ File $file encrypted"
@@ -30,9 +40,9 @@ sops_encrypt_file() {
 
 # Decrypt file using AGE encryption
 sops_decrypt_file() {
-    file=$1
+    local file="$1"
     if [[ $SOPS_ENABLED == 1 && -n $file && -f /data/${file} ]]; then
-        if ! $SOPS_CMD filestatus "/data/${file}" | grep -q '"encrypted":true'; then
+        if ! sops_is_encrypted "/data/${file}"; then
             echo "• File $file not encrypted, skipping"
         elif $SOPS_CMD decrypt --in-place "/data/${file}"; then
             echo "✓ File $file decrypted"


### PR DESCRIPTION
## What

Optional at-rest encryption for cached auth + downloader credential files on the `/data` volume, using [sops](https://github.com/getsops/sops) with age.

## Changes

- **`scripts/sops.sh`** — helper sourced by entrypoint:
  - `sops_encrypt_file` / `sops_decrypt_file`: **in-place** (`--in-place`), no plaintext `.enc` sidecar left behind
  - `filestatus` guard both sides → re-runs don't double-encrypt/decrypt or abort under `set -euo pipefail`
  - `sops_unset_envs`: strips age keys from env before server `exec`
- **`docker-entrypoint.sh`** — decrypt before token load, re-encrypt after save; same around downloader run
- **`Dockerfile`** — bundle `sops` binary via multi-stage build, copy `scripts/`
- **`docker-compose.yml`** — `build`, `env_file: .env`

## Config

| var | purpose |
|--|--|
| `SOPS_AGE_KEY` | age **secret** key — decrypt (auto-enables sops) |
| `SOPS_AGE_RECIPIENT` | age **public** key — encrypt recipient |
| `SOPS_ENABLED` | force toggle (auto-on when key set) |

Encrypt needs the public recipient; decrypt needs the secret. No plaintext token file survives the happy path (`save_auth_tokens` always re-encrypts in place).

## Notes

- Secrets kept in `.env` (gitignored); nothing sensitive committed.
- `unset` reduces exposure to the server process, but the key still lives in the container config (`docker inspect` / `env_file`) — partial, not full containment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added encrypted handling for server-related cache and credential files during container startup.
  * Included SOPS support in the container image and startup flow.

* **Bug Fixes**
  * Improved startup reliability with stricter shell settings.
  * Updated container configuration to build locally and load environment variables from a `.env` file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->